### PR TITLE
feature(wmic):使用PowerShell替代已弃用的wmic命令

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ vendor
 bin
 dist
 release
+lkctl
+lkverify
+lkctl.exe
+lkverify.exe
 demo
 vendor
 coverage.html


### PR DESCRIPTION
## get system uuid/cpuid use PowerShell

* 使用PowerShell替代已弃用的wmic命令
* Microsoft在Windows 10版本1903之后开始弃用wmic命令
* 推荐使用PowerShell的Get-CimInstance命令替代
* 新的解决方案在所有现代Windows系统上都能正常工作

## 功能改进

- [x] 新功能（添加功能的非破坏性变更）
- [x] 文档更新
- [x] 性能改进
- [x] 代码重构
- [x] 测试改进
- [x] 构建/CI 改进

## 测试

- [x] 单元测试
- [x] 集成测试
- [x] 手动测试

**测试配置**：
* Go 版本：1.23.4\1.24.0
* 操作系统：
  * macos
  * windows 11
  * ubuntu22.04

## 检查清单

- [x] 我的代码遵循此项目的代码风格指南
- [x] 我已经对我的代码进行了自我审查
- [x] 我已经对我的代码进行了注释，特别是在难以理解的区域
- [x] 我已经对我的变更进行了相应的文档更新
- [x] 我的变更不会产生新的警告
- [x] 我已经添加了证明我的修复有效或我的功能工作的测试
- [x] 新的和现有的单元测试在我的变更下都能通过
- [x] 任何依赖的变更都已经合并并发布
